### PR TITLE
npm package and webpack plugin

### DIFF
--- a/auxpack-npm/index.js
+++ b/auxpack-npm/index.js
@@ -1,0 +1,31 @@
+const path = require('path');
+const fs = require('fs');
+const parseStats = require('./utils/parser');
+const server = require('./utils/server');
+
+module.exports = class Auxpack {
+  constructor() {  }
+  
+  apply(compiler) {
+      let data;
+      const target = path.resolve(__dirname, '..', '../aux-stats.json');
+
+      //GETTING PREVIOUS STATS, OR SETTING A BLANK ARRAY
+      if (fs.existsSync(target)) {
+        data = JSON.parse(fs.readFileSync(target, { encoding: 'utf8' }));
+      } else {
+        data = [];
+      }
+
+      compiler.hooks.done.tap('MonitorStats', stats => {
+        stats = stats.toJson();
+        const parsed = parseStats(stats, target);
+        data.push(parsed)
+        console.log('\n\nAUXPACK STATS RECORDED\nCURRENT BUILD:\n', parsed);
+        fs.writeFile(target, JSON.stringify(data), (err) => {
+          if (err) throw err;
+          server(data)
+        });
+    });
+  }
+};

--- a/auxpack-npm/package.json
+++ b/auxpack-npm/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "auxpack",
+  "version": "1.0.2c",
+  "description": "A dashboard for monitoring Webpack build stats.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "N.Ajito, S.Chiu, T.Clark, C.Lai",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.17.1",
+    "opener": "^1.5.1"
+  }
+}

--- a/auxpack-npm/utils/parser.js
+++ b/auxpack-npm/utils/parser.js
@@ -1,0 +1,29 @@
+module.exports = (stats) => {
+
+  return {
+    timeStamp: Date.now(),
+    time: stats.time,
+    hash: stats.hash,
+    errors: stats.errors,
+
+    size: stats.assets.reduce((totalSize, asset) => totalSize + asset.size, 0),
+
+    assets: stats.assets.map(asset => ({
+      name: asset.name,
+      chunks: asset.chunks,
+      size: asset.size
+    })),
+
+    chunks: stats.chunks.map(chunk => ({
+      size: chunk.size,
+      files: chunk.files,
+      modules: chunk.modules
+        ? chunk.modules.map(module => ({
+            name: module.name,
+            size: module.size,
+            id: module.id
+          }))
+        : []
+    }))
+  };
+};

--- a/auxpack-npm/utils/server.js
+++ b/auxpack-npm/utils/server.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const opener = require('opener');
+const chalk = require('chalk');
+
+module.exports = (data) => {
+  const app = express();
+  const PORT = 3000;
+  const url = `http://localhost:${PORT}/`;
+
+  app.get('/', (req, res) => {
+    res.json(data);
+  });
+
+  app.listen(PORT, () => {
+    opener(url)
+    console.log(chalk.inverse(`Auxpack on port ${PORT}`))
+  });
+};


### PR DESCRIPTION
- I've written and published auxpack to npm, which is the architecture for our npm package
- The package is installable from npm with:
`npm i auxpack -D`
`npm run build`
and in webpack.config.js, include:
`const Auxpack = require('auxpack');
...
plugins: [
  new Auxpack(),
]`
- the npm package offers a webpack plugin which intercepts stats, to be sent to the front end
- if run currently, it will load a browser window at port 1111 with an array of build stats

NOTE: 
- I am working toward serving the bundled frontend, so this will not run on current frontend; aka, at present, it will send only an array of prior build data
- I have this written for simplicity, for MVP purposes. The code is light and digestible