### PR TITLE
Expansion Panels overflowY and Modules.jsx Cards to Material UI expansion panels

### DIFF
--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -152,6 +152,9 @@ div.row{ // this styles the content inside scrollable window
 .expansionPanel {
     width: 40%;
 }
+.tab-panel {
+    overflow-y: auto;
+}
 .tabs-section {
     min-width: 150px;
     margin-bottom: 20px;

--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -149,7 +149,9 @@ div.row{ // this styles the content inside scrollable window
 // .mw-40 {
 //     max-width: 40%;
 // }
-
+.expansionPanel {
+    width: 40%;
+}
 .tabs-section {
     min-width: 150px;
     margin-bottom: 20px;

--- a/src/client/content/components/ChangesTable.jsx
+++ b/src/client/content/components/ChangesTable.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
@@ -120,8 +119,10 @@ const ChangesTable = (props) => {
         const classes = useStyles();
 
         return (
-            <div className={classes.root}>
-                <ExpansionPanel >
+            <div className={classes.root} >
+                <ExpansionPanel className="expansionPanel" style={{
+                    width: '800px',
+                }} >
                     <ExpansionPanelSummary
                         expandIcon={<ExpandMoreIcon />}
                         aria-controls="panel1a-content"
@@ -138,11 +139,14 @@ const ChangesTable = (props) => {
                     </ExpansionPanelDetails>
                 </ExpansionPanel>
                 {/* Second expansion */}
-                <ExpansionPanel>
+                <ExpansionPanel className="expansionPanel" style={{
+                    width: '800px',
+
+                }}>
                     <ExpansionPanelSummary
                         expandIcon={<ExpandMoreIcon />}
-                        aria-controls="panel2a-content"
-                        id="panel2a-header"
+                        aria-controls="panel1a-content"
+                        id="panel1a-header"
 
                     >
                         {/* Expansion heading */}

--- a/src/client/content/components/ChangesTable.jsx
+++ b/src/client/content/components/ChangesTable.jsx
@@ -133,7 +133,10 @@ const ChangesTable = (props) => {
                             <strong className="centered">Additions</strong>
                         </Typography>
                     </ExpansionPanelSummary>
-                    <ExpansionPanelDetails>
+                    <ExpansionPanelDetails style={{
+                        maxHeight: '400px',
+                        overflowY: 'auto'
+                    }}>
                         {/* Additions Card Panel - content*/}
                         <AdditionCard />
                     </ExpansionPanelDetails>
@@ -141,7 +144,6 @@ const ChangesTable = (props) => {
                 {/* Second expansion */}
                 <ExpansionPanel className="expansionPanel" style={{
                     width: '800px',
-
                 }}>
                     <ExpansionPanelSummary
                         expandIcon={<ExpandMoreIcon />}
@@ -154,7 +156,10 @@ const ChangesTable = (props) => {
                             <strong className="centered">Removals</strong>
                         </Typography>
                     </ExpansionPanelSummary>
-                    <ExpansionPanelDetails>
+                    <ExpansionPanelDetails style={{
+                        maxHeight: '400px',
+                        overflowY: 'auto'
+                    }}>
                         {/* Removals Card Panel - content*/}
                         <RemovalCard />
                     </ExpansionPanelDetails>

--- a/src/client/content/components/ChangesTable.jsx
+++ b/src/client/content/components/ChangesTable.jsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-const ChangesTable = (props) => {
+const ChangesTable = props => {
     const { dirFinalArrayPrev, dirFinalArray, getBytes } = props;
     // console.log(`prev: `, props.dirFinalArrPrev, `current: `, dirFinalArray)
 

--- a/src/client/content/components/Modules.jsx
+++ b/src/client/content/components/Modules.jsx
@@ -1,40 +1,122 @@
 import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import Typography from '@material-ui/core/Typography';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+
+const useStyles = makeStyles(theme => ({
+    root: {
+        width: '100%',
+    },
+    heading: {
+        fontSize: theme.typography.pxToRem(15),
+        fontWeight: theme.typography.fontWeightRegular,
+    },
+}));
 
 const Modules = props => {
+    const { dirFinalArray, getBytes } = props;
 
-    const fileTable = props.dirFinalArray.map((directory) => {
-        const fileListItems = directory[1].map((file, j) => (
-            <tr key={file.filename + file.size + j}>
-                <td>{file.filename}</td>
-                <td>{props.getBytes(file.size)}</td>
-                <td>{file.percentage}</td>
-            </tr>
-        ));
+    const fileRows = dirFinalArray.map((directory) => {
+        return directory[1].map((file, j) => (<tr key={file.filename + file.size + j}>
+            <td>{file.filename}</td>
+            <td>{getBytes(file.size)}</td>
+            <td>{file.percentage}</td>
+        </tr>)
+        )
+    })
+
+    const FileTable = () => {
+        return (<table className="highlight">
+            <thead>
+                <tr className="card-body">
+                    <th>File Name</th>
+                    <th>Size</th>
+                    <th>Percentage</th>
+                </tr>
+            </thead>
+            <tbody>
+                {fileRows}
+            </tbody>
+        </table>)
+    }
+    // const FileTable = props.dirFinalArray.map((directory) => {
+    //     const fileListItems = directory[1].map((file, j) => (
+    //         <tr key={file.filename + file.size + j}>
+    //             <td>{file.filename}</td>
+    //             <td>{props.getBytes(file.size)}</td>
+    //             <td>{file.percentage}</td>
+    //         </tr>
+    //     ));
+
+    // return (
+    //     <div className="card module-card mw-40 darken-1" key={directory[0]}>
+    //         <div className="card-content">
+    //             <span className="card-title">{directory[0]}</span>
+    //             <table className="highlight centered">
+    //                 <thead>
+    //                     <tr className="card-body">
+    //                         <th>File Name</th>
+    //                         <th>File Size</th>
+    //                         <th>Percentage</th>
+    //                     </tr>
+    //                 </thead>
+    //                 <tbody>
+    //                     {fileListItems}
+    //                 </tbody>
+    //             </table >
+    //         </div>
+    //     </div>
+    // );
+    //     return (<table className="highlight">
+    //         <thead>
+    //             <tr className="card-body">
+    //                 <th>File Name</th>
+    //                 <th>File Size</th>
+    //                 <th>Percentage</th>
+    //             </tr>
+    //         </thead>
+    //         <tbody>
+    //             {fileListItems}
+    //         </tbody>
+    //     </table >)
+    // }); // end fileTable component
+
+    const SimpleExpansionPanel = () => {
+        const classes = useStyles();
 
         return (
-            <div className="card module-card mw-40 darken-1" key={directory[0]}>
-                <div className="card-content">
-                    <span className="card-title">{directory[0]}</span>
-                    <table className="highlight centered">
-                        <thead>
-                            <tr className="card-body">
-                                <th>File Name</th>
-                                <th>File Size</th>
-                                <th>Percentage</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {fileListItems}
-                        </tbody>
-                    </table >
-                </div>
+            <div className={classes.root} >
+                <ExpansionPanel className="expansionPanel" style={{
+                    width: '800px',
+                }} >
+                    <ExpansionPanelSummary
+                        expandIcon={<ExpandMoreIcon />}
+                        aria-controls="panel1a-content"
+                        id="panel1a-header"
+                    >
+                        <Typography className={classes.heading} className="expansion-heading">
+                            {/* Expansion heading */}
+                            <strong className="centered">Modules</strong>
+                        </Typography>
+                    </ExpansionPanelSummary>
+                    <ExpansionPanelDetails style={{
+                        maxHeight: '60%',
+                        overflowY: 'auto'
+                    }}>
+                        {/* FileTable - content*/}
+                        <FileTable />
+                    </ExpansionPanelDetails>
+                </ExpansionPanel>
             </div>
         );
-    }); // end fileTable component
+    }
 
     return (
-        <div className="modules-container">
-            {fileTable}
+        <div className="cards-container centered">
+            <SimpleExpansionPanel />
         </div>
     );
 }

--- a/src/client/content/containers/BuildData.jsx
+++ b/src/client/content/containers/BuildData.jsx
@@ -144,6 +144,7 @@ const BuildData = ({ build, activeBuild }) => {
             <TabPanel value={value} index={0} className="tab-panels" style={{
                 display: 'flex',
                 justifyContent: 'center',
+                border: '1px solid blue'
             }}>
                 <ChangesTable
                     build={build}

--- a/src/client/content/containers/BuildData.jsx
+++ b/src/client/content/containers/BuildData.jsx
@@ -124,7 +124,8 @@ const BuildData = ({ build, activeBuild }) => {
     return (
         <div className="build-data" className={classes.root} style={{
             height: '550px',
-            maxHeight: '40%'
+            maxHeight: '40%',
+            borderRadius: '4px'
         }}>
             <Tabs
                 orientation="vertical"
@@ -140,7 +141,10 @@ const BuildData = ({ build, activeBuild }) => {
                 <Tab label="Errors" {...a11yProps(2)} />
                 <Tab label="Modules" {...a11yProps(3)} />
             </Tabs>
-            <TabPanel value={value} index={0} className="tab-panels">
+            <TabPanel value={value} index={0} className="tab-panels" style={{
+                display: 'flex',
+                justifyContent: 'center',
+            }}>
                 <ChangesTable
                     build={build}
                     activeBuild={activeBuild}
@@ -165,7 +169,9 @@ const BuildData = ({ build, activeBuild }) => {
                     activeBuild={activeBuild}
                 />
             </TabPanel>
-            <TabPanel value={value} index={3} className="tab-panels">
+            <TabPanel value={value} index={3} className="tab-panels" style={{
+                border: '1px solid blue'
+            }}>
                 <Modules
                     build={build}
                     activeBuild={activeBuild}

--- a/src/client/content/containers/BuildData.jsx
+++ b/src/client/content/containers/BuildData.jsx
@@ -123,7 +123,7 @@ const BuildData = ({ build, activeBuild }) => {
 
     return (
         <div className="build-data" className={classes.root} style={{
-            height: '550px',
+            height: '700px',
             maxHeight: '40%',
             borderRadius: '4px'
         }}>


### PR DESCRIPTION
1. Added fixed width for expansion panels and overflowY auto for the tab panel section.
2. Commented out materialize cards in Modules.jsx and added Material UI expansion panels for modules table.